### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/thanadolps/snss/compare/v0.1.0...v0.1.1) - 2025-06-22
+
+### Other
+
+- add parsing test
+- integrate cargo-diet

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "snss"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "snss"
 description = "Basic SNSS file parsing (eg. Chrome Session and Tabs Files)"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 repository = "https://github.com/thanadolps/snss"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `snss`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/thanadolps/snss/compare/v0.1.0...v0.1.1) - 2025-06-22

### Other

- add parsing test
- integrate cargo-diet
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).